### PR TITLE
Added pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "nvda-mathcat"
+version = "20250706"
+readme = "README.md"
+requires-python = ">=3.11,<3.12"
+
+[project.urls]
+Homepage = "https://www.nvaccess.org/"
+Repository = "https://github.com/nvaccess/nvda-mathcat.git"
+
+[build-system]
+requires = ["setuptools~=72.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+include-package-data = true


### PR DESCRIPTION
This PR adds a pyproject.toml file to nvda-mathcat, similar to the pyproject.toml in nvda-misc-deps.
