### PR TITLE
Update REQUIRED_ASSETS for 64-bit version

### DIFF
--- a/.github/workflows/fetchAssets.yaml
+++ b/.github/workflows/fetchAssets.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       REQUIRED_ASSETS: |
         Rules.zip
-        libmathcat_py-32-3.11-win.zip
+        libmathcat_py-64-3.11-win.zip
       RELEASE_URL: https://api.github.com/repos/NSoiffer/MathCATForPython/releases/latest
 
     steps:


### PR DESCRIPTION
This pull request updates the asset requirements in the GitHub Actions workflow for fetching assets. The change ensures that the workflow now requests the correct version of the Python library for Windows.

* Updated the `REQUIRED_ASSETS` environment variable in `.github/workflows/fetchAssets.yaml` to require `libmathcat_py-64-3.11-win.zip` instead of the 32-bit version.